### PR TITLE
Basic Post and Delete router for crewai chatbot

### DIFF
--- a/routers/message_router.py
+++ b/routers/message_router.py
@@ -81,5 +81,9 @@ async def send_message(payload: MessageBaseSchema,session: AsyncSession = Depend
             detail=f"Error POST: {ex}"
         )
 
-
+from sqlmodel import delete
+@router.delete("/clear", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_list(session: AsyncSession = Depends(get_session)):
+    result = await session.execute(delete(Message))
+    await session.commit()
 


### PR DESCRIPTION
**Overview:**

- With a new endpoint for message router can now be tested and work in swagger. Now it could perform post and delete. Only these one are added because these will be useful in my current situation. I'll add more endpoints only if my application grow more from here
- Fixed #26 

**Changes made:**

- Added Post "/send-message" endpoint to send message and generate answer of llm with persistence of conversation using postgres database.
- Added Delete "/clear" endpoint for deleting all messages. Good for testing since i dont need to manually delete one by one. This deletes all the contents. 

**Quality Checklist**

- [x] KISS (Keep it simple, stupid!)
- [x] Solid Code
