### PR TITLE
Fixed bug in sqlmodel importing models

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,3 @@
+from models.message_model import Message
+from models.conversation_model import Conversation
+from models.user_model import User


### PR DESCRIPTION
**Overview:**

During swagger when testing api, Error occurs about Message, Conversation and User models. Recently learned that SQLModel is lazy loaded so it needs explicit imports.  

**Changes made:**

Added User, Message, and Conversation imports inside models/__init__.py