### PR TITLE
Refactor/Migrate Sparse embedding function

### DIFF
--- a/llm_workflow/vector_stores/vector_connection.py
+++ b/llm_workflow/vector_stores/vector_connection.py
@@ -1,8 +1,8 @@
 from typing import Optional
 from llama_index.vector_stores.milvus import MilvusVectorStore
-from llama_index.vector_stores.milvus.utils import  BM25BuiltInFunction#,BGEM3SparseEmbeddingFunction
+from llama_index.vector_stores.milvus.utils import  BM25BuiltInFunction
 from dotenv import load_dotenv
-from cachetools import TTLCache, LRUCache
+from cachetools import LRUCache
 from pymilvus import AsyncMilvusClient
 from fastapi import HTTPException, status
 import os
@@ -17,13 +17,7 @@ class MilvusVectorStoreClassAsync:
         self.cache = LRUCache(maxsize=100)
         self.master_lock = asyncio.Lock()
         self.user_locks = {}
-        # self._bgem3function = None
 
-    # @property
-    # def bgem3function(self) -> BGEM3SparseEmbeddingFunction:
-    #     if self._bgem3function is None:
-    #         self._bgem3function = BGEM3SparseEmbeddingFunction()
-    #     return self._bgem3function
 
     @property
     def bm25function(self) -> BM25BuiltInFunction:
@@ -56,7 +50,7 @@ class MilvusVectorStoreClassAsync:
                 similarity_metric="IP",
                 consistency_level="Session",
                 hybrid_ranker="RRFRanker",
-                hybrid_ranker_params={"k": 80}
+                hybrid_ranker_params={"k": 60}
             )
             return vector_store
         except Exception as x:


### PR DESCRIPTION
**Description:** 

Original BGE-3M Sparse embedding will now be changed to BM25 sparse embedding function

**Why:**

Because lately when i use bge3m function it feels heavy, and when i tested docker build i found it built around 1 hour, which was unusual for me because build time is only around 5 mins. So I've change it just now. Also to those that might think that why i change now when i didn't change before, because before build time is the same even with those heavy weight third party packages exist it still 5 mins build time which is one of the advantage of this open source project, being lightweight. 

Also from issue #67 , flagembedding was removed which holds the logic for BGE-M3 and has torch python package. This flagembedding has 26gb size file docker when built which i change to something light and use BM25 which is also built-in and used in milvus vector store configuration for hybrid search (dense and sparse).

**Changes made:**

- Remove BGE-M3 import
- Remove BGE-M3 property and change it to BM25 property
- The config inside milvus vector store is now usin BM25 propert

**Quality checklist:**

- [x] KISS
- [x] YAGNI