### PR TITLE
perf: Added additional config for better hybrid search in burmese, la…

### DIFF
--- a/llm_workflow/vector_stores/vector_connection.py
+++ b/llm_workflow/vector_stores/vector_connection.py
@@ -13,7 +13,18 @@ from llm_workflow.config_files.locking import LockManager
 
 CLIENT_URI=settings_for_workflow.CLIENT_URI.get_secret_value()
 CLIENT_TOKEN=settings_for_workflow.CLIENT_TOKEN.get_secret_value()
-BM25FUNCTION = BM25BuiltInFunction()
+BM25FUNCTION = BM25BuiltInFunction(
+    analyzer_params={
+        "tokenizer": "icu",
+        "filter": [
+            "lowercase",
+            {"type": "length", "max": 40},
+        ],
+    },
+    enable_match=True,
+    input_field_names=["text"],
+    output_field_names=["sparse_embeddings"]
+)
 VECTOR_CACHE = LRUCache(maxsize=1000)
 CACHE_FOR_LOCK = LRUCache(maxsize=1000)
 ASYNC_LOCK = asyncio.Lock()


### PR DESCRIPTION
**Description:**

Optimized the BM25BuiltInFunction configuration to improve hybrid search accuracy for Southeast Asian languages (Lao, Burmese, and Tagalog).

**Why this PR:**

- Script-Aware Tokenization: Switched to the icu tokenizer to handle scriptio continua (no spaces) in Lao and Burmese. Standard tokenizers treat these sentences as single tokens, breaking BM25 keyword matching.

- Hybrid Synergy: Complements Cohere v4.0 (1536-dim) dense embeddings with word-level sparse vectors, ensuring high-fidelity retrieval for both semantic meaning and specific local terms/slang.

- Ranking: Maintains RRF (k=60) to balance dense/sparse scores without weighting bias.

**Changes made:**

- Added additional configuration for the existing and default value for bm25