### PR TITLE
Refactor: Solid code integration and implicit path directory access to prompts

### DIFF
--- a/llm_workflow/prompts/prompt_library.py
+++ b/llm_workflow/prompts/prompt_library.py
@@ -1,30 +1,49 @@
 import yaml
 import json
 from typing import Dict, Union, Any
+from abc import ABC, abstractmethod
+from pathlib import Path
 from llama_index.core.prompts import PromptTemplate
+try:
+    from importlib import resources
+except ImportError:
+    import importlib_resources as resources
 
 
-class PromptLibrary:
-    def __init__(self, file_path: str = "prompts.yaml"):
-        self.filepath = file_path
-        self.prompt = self._load_yaml()
+class LoaderABC(ABC):
+    def __init__(self, file_path: Union[str, None] = None):
+        self.file_path = file_path
 
-    def _load_yaml(self) -> Dict[str, Any]:
+    @abstractmethod
+    def _load_resources(self) -> Dict[str, Any]:
+        pass
+
+    @abstractmethod
+    def get_prompt(self, key_path: str) -> str:
+        pass
+
+
+class LibraryLoader(LoaderABC):
+    def __init__(self, file_path: Union[str, None] = None):
+        super().__init__(file_path)
+        self.base_dir = Path(__file__).parent
+        self.data = self._load_resources()
+
+    def _load_resources(self) -> Dict[str, Any]:
         try:
-            with open(self.filepath, "r", encoding="utf-8") as file:
-                return yaml.safe_load(file)
+            full_path = self.base_dir/self.file_path
+            with open(full_path, "r", encoding="utf-8") as file:
+                return yaml.safe_load(file) or {}
 
-        except FileNotFoundError:
+        except (FileNotFoundError, yaml.YAMLError):
             return {}
 
 
     def get_prompt(self, key_path: str) -> str:
-        keys = key_path.split(".")
-        data = self.prompt
-
+        data = self.data
         try:
-            for key in keys:
-                data = data[key]
+            for keys in key_path.split("."):
+                data = data[keys]
 
             if isinstance(data, (dict,list)):
                 return json.dumps(data, indent=2, ensure_ascii=False)
@@ -39,3 +58,15 @@ class PromptLibrary:
         template_obj = PromptTemplate(template=template)
         final_template = template_obj.format(**kwargs)
         return final_template
+
+
+class BasePrompt:
+    def __init__(self, yaml_file_name: Union[str, None] = None):
+        self.loader = LibraryLoader(file_path=yaml_file_name)
+
+    def get_prompt(self, key_path: str) -> str:
+        return self.loader.get_prompt(key_path=key_path)
+
+class PromptLibrary(BasePrompt):
+    def __init__(self):
+        super().__init__("prompts.yaml")


### PR DESCRIPTION
**Overview:**

Refactoring the explicit base directory and current path to parameter of PromptLibrary, which might be hard if you dont understand pathlib, so i made a code that only need to instantiate and would automatically set the direction where prompt file or other file you want to extract  with. 

**Why:**

First time i had fun refactoring and fix my code using Solid code OCP, which i don't actually understand 3 days ago. Now i could make one, thought i might still be lost, but the concept make me happy that i can do something more about it in the future.

**Changes made:**

- Added abstract base classes and implement it to the existing class
- Make a wrapper for code so that it can be extend when needed


**Quality checklist:**

- [x] Composition over inheritance
- [x] Open-Close Principle
- [x] Single Responsibility Principle
- [x] KISS