### PR TITLE
Fixed bug/139 Docker deployment bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.13-slim-trixie
 
-COPY --from=ghcr.io/astral-sh/uv:0.8.4 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.8.4 /uv /uvx /usr/local/bin/
 
 WORKDIR /app
 
@@ -14,11 +14,8 @@ RUN uv sync --frozen --no-cache --no-install-project
 
 COPY . /app
 
-RUN uv sync --frozen --no-cache
-
-#CMD ["/app/.venv/bin/uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
-
-COPY entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
+
+RUN uv sync --frozen --no-cache
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # entrypoint.sh
 
 set -e

--- a/main.py
+++ b/main.py
@@ -7,12 +7,12 @@ app = FastAPI()
 app.include_router(llm_router)
 
 
-if __name__ == "__main__":
-    import uvicorn
-    print("RUNNING UVICORN")
-    uvicorn.run(
-        "main:app",
-        host="0.0.0.0",
-        port=8000,
-        reload=True
-    )
+# if __name__ == "__main__":
+#     import uvicorn
+#     print("RUNNING UVICORN")
+#     uvicorn.run(
+#         "main:app",
+#         host="0.0.0.0",
+#         port=8000,
+#         reload=False
+#     )


### PR DESCRIPTION
**Overview:**

Deploy in my machine works but has inconsistent error and most of the time it doesn't reach the entrypoint.sh file because it cant detect it. But I just found out Docker slim trixie is Debian not Ubuntu, so Bash will likely fail. So i use sh instead of bash to keep it constant and smooth deployment. 

**Changes made:**

- use /usr/local/bin/ instead of /bin/ to separate the usual install folder
- remove duplicate because app/ and entrypoint.sh are copied together separately, i remove the redundant entrypoint.sh (because it is already has copied version during COPY /app)
- remove unnecessary files and keep docker and docker compose clean.

**Quality checklist:**

- [x] KISS