### PR TITLE
Fix: Security bypass ufw and nginx and direct access to docker services. 

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     image: miako
     container_name: miako-backend-container
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
 
     env_file:
       - .env
@@ -24,8 +24,8 @@ services:
       - POSTGRES_PASSWORD=${DB_PASS}
       - POSTGRES_DB=${DB_NAME}
       - POSTGRES_USER=${DB_USER}
-    ports:
-      - "5432:5432"
+#    ports:
+#      - "5432:5432"
     volumes:
       - miako-data-volume:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
**Description:**
When i was testing redis, i was notified by my AI that exposing port 6379:6379 will let it be exposed in the web were nginx and ufw and crowdsec might not be able to catch that. So i change and modify few configurations

**Changes made:**
- Backend 8000:8000 bind it to 127.0.0.1. Bind is like this -> 127.0.0.1:8000:8000
- Postgres is also removed, as i just learn in docker, all default that arent explicitly added will only work inside docker network. Means that it will be not exposed outside or in localhost so it will be safe, letting backend bind to localhost is enough. 
- Postgres also has internal default port as 5432:5432, so backend will only detect that database as outside forces wont be able to because this one lives inside container, 

**Quality checklist:**
- [x] KISS
- [x] YAGNI
- [ ] DRY
- [ ] SRP
- [ ] OCP
- [ ] Composition over Inheritance